### PR TITLE
Update realismAddon_fillables.lua

### DIFF
--- a/FS22_realismAddon_fillables/realismAddon_fillables.lua
+++ b/FS22_realismAddon_fillables/realismAddon_fillables.lua
@@ -234,7 +234,7 @@ function realismAddon_fillables:addFillUnitFillLevel(superFunc, farmId, fillUnit
 	
 		local fillUnit = spec.fillUnits[fillUnitIndex]
 		
-		if realismAddon_fillables.checkExcludeFillType(fillUnit) then
+		if fillUnit ~= nil and realismAddon_fillables.checkExcludeFillType(fillUnit) then
 		
 			-- backup original capacity
 			local capacityOriginal = fillUnit.capacity


### PR DESCRIPTION
Fixed nil-condition with trailers that contain a variable count of fillVolumes.